### PR TITLE
Revert "pass log callback to prober instead of calling back early"

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ SentryLogger.prototype.log = function(level, msg, meta, callback) {
 
         if (this.sentryProber) {
             thunk = this.captureError.bind(null, msg, sentryArgs);
-            this.sentryProber.probe(thunk, callback);
+            this.sentryProber.probe(thunk);
         } else {
             this.captureError(msg, sentryArgs, callback);
         }
@@ -150,10 +150,14 @@ SentryLogger.prototype.log = function(level, msg, meta, callback) {
         if (this.sentryProber) {
             thunk = this.captureMessage
                 .bind(null, errLoc + ": " + msg, sentryArgs);
-            this.sentryProber.probe(thunk, callback);
+            this.sentryProber.probe(thunk);
         } else {
             this.captureMessage(errLoc + ": " + msg, sentryArgs, callback);
         }
+    }
+
+    if (this.sentryProber) {
+        callback(null, true);
     }
 };
 


### PR DESCRIPTION
Reverts uber/sentry-logger#11 

We shouldn't pass as callback unless we know the value of "detectFailuresBy" for the Prober instance.